### PR TITLE
Multi lib patch support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-ELASTICMOCK_VERSION='1.8.0+dd.1'
+ELASTICMOCK_VERSION='1.8.0+dd.2'
 
 install:
 	pip3 install -r requirements.txt

--- a/elasticmock/__init__.py
+++ b/elasticmock/__init__.py
@@ -52,9 +52,7 @@ def elasticmock(f, klasses_to_patch=None):
     @wraps(f)
     def decorated(*args, **kwargs):
         ELASTIC_INSTANCES.clear()
-        with nested(
-            *(patch(klass, _get_elasticmock) for klass in klasses_to_mock)
-        ):
+        with nested(*(patch(klass, _get_elasticmock) for klass in klasses_to_mock)):
             result = f(*args, **kwargs)
         return result
 

--- a/elasticmock/__init__.py
+++ b/elasticmock/__init__.py
@@ -27,7 +27,7 @@ from elasticmock.fake_elasticsearch import FakeElasticsearch
 
 ELASTIC_INSTANCES = {}
 # if you needed to patch elasticsearch6, elasticsearch7 as well
-ELASTIC_CLASSES_TO_PATCH = {
+DEFAULT_ELASTIC_CLASSES_TO_PATCH = {
     "elasticsearch.Elasticsearch",
 }
 
@@ -46,12 +46,14 @@ def _get_elasticmock(hosts=None, *args, **kwargs):
     return connection
 
 
-def elasticmock(f):
+def elasticmock(f, klasses_to_patch=None):
+    klasses_to_mock = klasses_to_patch or DEFAULT_ELASTIC_CLASSES_TO_PATCH
+
     @wraps(f)
     def decorated(*args, **kwargs):
         ELASTIC_INSTANCES.clear()
         with nested(
-            *(patch(klass, _get_elasticmock) for klass in ELASTIC_CLASSES_TO_PATCH)
+            *(patch(klass, _get_elasticmock) for klass in klasses_to_mock)
         ):
             result = f(*args, **kwargs)
         return result

--- a/elasticmock/__init__.py
+++ b/elasticmock/__init__.py
@@ -16,6 +16,8 @@ if PY3:
             for ctx in contexts:
                 stack.enter_context(ctx)
             yield contexts
+
+
 else:
     from mock import patch
     from contextlib import nested
@@ -25,7 +27,9 @@ from elasticmock.fake_elasticsearch import FakeElasticsearch
 
 ELASTIC_INSTANCES = {}
 # if you needed to patch elasticsearch6, elasticsearch7 as well
-ELASTIC_CLASSES_TO_PATCH = {"elasticsearch.Elasticsearch", }
+ELASTIC_CLASSES_TO_PATCH = {
+    "elasticsearch.Elasticsearch",
+}
 
 
 def _get_elasticmock(hosts=None, *args, **kwargs):
@@ -46,7 +50,9 @@ def elasticmock(f):
     @wraps(f)
     def decorated(*args, **kwargs):
         ELASTIC_INSTANCES.clear()
-        with nested(*(patch(klass, _get_elasticmock) for klass in ELASTIC_CLASSES_TO_PATCH)):
+        with nested(
+            *(patch(klass, _get_elasticmock) for klass in ELASTIC_CLASSES_TO_PATCH)
+        ):
             result = f(*args, **kwargs)
         return result
 

--- a/elasticmock/__init__.py
+++ b/elasticmock/__init__.py
@@ -7,12 +7,25 @@ from six import PY3
 
 if PY3:
     from unittest.mock import patch
+
+    from contextlib import ExitStack, contextmanager
+
+    @contextmanager
+    def nested(*contexts):
+        with ExitStack() as stack:
+            for ctx in contexts:
+                stack.enter_context(ctx)
+            yield contexts
 else:
     from mock import patch
+    from contextlib import nested
+
 
 from elasticmock.fake_elasticsearch import FakeElasticsearch
 
 ELASTIC_INSTANCES = {}
+# if you needed to patch elasticsearch6, elasticsearch7 as well
+ELASTIC_CLASSES_TO_PATCH = {"elasticsearch.Elasticsearch", }
 
 
 def _get_elasticmock(hosts=None, *args, **kwargs):
@@ -33,7 +46,7 @@ def elasticmock(f):
     @wraps(f)
     def decorated(*args, **kwargs):
         ELASTIC_INSTANCES.clear()
-        with patch("elasticsearch.Elasticsearch", _get_elasticmock):
+        with nested(*(patch(klass, _get_elasticmock) for klass in ELASTIC_CLASSES_TO_PATCH)):
             result = f(*args, **kwargs)
         return result
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 import setuptools
 
-__version__ = "1.8.0+dd.1"
+__version__ = "1.8.0+dd.2"
 
 # read the contents of your readme file
 from os import path


### PR DESCRIPTION
this only patches `elasticsearch.Elasticsearch` but if you use https://pypi.org/project/elasticsearch6/ or https://pypi.org/project/elasticsearch7/ for example, you can't mock these.